### PR TITLE
Specify timeout for downloading poco

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ if(NOT Poco_FOUND)
   ExternalProject_Add(poco-1.7.7
     URL https://github.com/pocoproject/poco/archive/poco-1.7.7-release.tar.gz
     URL_MD5 247b97b545715dc38c8619e412fbcd96
+    TIMEOUT 600
     CMAKE_ARGS
       -DENABLE_CPPUNIT:BOOL=OFF
       -DENABLE_CRYPTO:BOOL=OFF


### PR DESCRIPTION
The OS X packaging job has had connectivity issues the last few nights. [This job](http://ci.ros2.org/job/packaging_osx/534/console) is currently stuck trying to download poco with no timeout.

[This job](http://ci.ros2.org/job/ci_osx/1757/consoleFull) took 5 minutes to download it so I set the timeout at 10 minutes to avoid false positives, perhaps that is un-necessarily high.

[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1764)](http://ci.ros2.org/job/ci_osx/1764/) (I don't understand why this can't be merged automatically so that job uses a custom repos file with this branch)