### PR TITLE
Prepare release 1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(poco_vendor VERSION "1.0.0")
+project(poco_vendor VERSION "1.1.0")
 
 # Can work with poco 1.4.1p1 (earliest to use recursive mutexes on Linux)
 # 1.6.1 is the first version to ship with PocoConfigVersion.cmake

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>poco_vendor</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>CMake shim over the poco library.</description>
   <maintainer email="steven@openrobotics.org">Steven! Ragnarök</maintainer>
   <license>Apache License 2.0</license> <!-- The contents of this vendor package are Apache 2.0 -->


### PR DESCRIPTION
The commit from this PR should be fast-forwarded onto master when approved rather than merged.

Since a recent attempt to remove the version from CMake was unsuccessful (#16) I wanted CI to give me confidence that bumping the version wouldn't affect downstream packages.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4760)](http://ci.ros2.org/job/ci_linux/4760/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1626)](http://ci.ros2.org/job/ci_linux-aarch64/1626/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3947)](http://ci.ros2.org/job/ci_osx/3947/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4818)](http://ci.ros2.org/job/ci_windows/4818/)